### PR TITLE
Include a minimalistic nodejs lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # quickstart-nodejs
+
+Node.js sample application for Screwdriver
+
+## Pipeline
+
+### Fail to Publish
+
+The `publish` job is properly defined in the `screwdriver.yaml`. The package is purposely configured to fail.
+
+Given that this package is basic, we don't want to flood the NPM Registry with quickstart modules. The included `package.json` file contains a `private: true` flag to safeguard against publishing to the NPM Registry.
+
+## Dev
+
+### Requirements
+
+* [NodeJS](https://nodejs.org/en/)
+* NPM (included in the NodeJS package)
+
+### Install dependencies
+
+```
+$ npm install
+```
+
+### Run tests
+
+```
+$ npm test
+```
+

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = () => {
+    return 'Hello Node';
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "screwdriver-quickstart-nodejs",
+  "version": "1.0.0",
+  "description": "A quickstart repository, which serves as an example of how to use Screwdriver with NodeJS",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/screwdriver-cd-test/quickstart-nodejs.git"
+  },
+  "keywords": [
+    "screwdriver",
+    "screwdriver-cd",
+    "yahoo",
+    "continuous delivery",
+    "cd",
+    "continuous integration",
+    "ci"
+  ],
+  "author": "Darren Matsumoto <aeneascorrupt@gmail.com>",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/screwdriver-cd-test/quickstart-nodejs/issues"
+  },
+  "homepage": "https://github.com/screwdriver-cd-test/quickstart-nodejs#readme",
+  "private": true,
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.2.0"
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+describe('Index Unit Test', () => {
+    it('works', () => {
+        const main = require('../');
+        const result = main();
+
+        expect(result).to.equal('Hello Node');
+    });
+});


### PR DESCRIPTION
When users choose to fork this repository and run it themselves, the `main` job should succeed as a proper NodeJS project.

The `publish` job will require an NPM auth token, so that should be expected to fail. Since this package is basic and we don't want to flood the registry with quickstart modules, we also include the `private: true` flag to safeguard against that behavior.